### PR TITLE
fix: restore synchronous bootstrap execution

### DIFF
--- a/crates/agency/src/commands/attach.rs
+++ b/crates/agency/src/commands/attach.rs
@@ -7,7 +7,7 @@ use crate::daemon_protocol::{
   C2D, C2DControl, D2C, D2CControl, ProjectKey, read_frame, write_frame,
 };
 use crate::utils::daemon as dutil;
-use crate::utils::daemon::{get_project_state, send_start_bootstrap};
+use crate::utils::daemon::get_project_state;
 use crate::utils::git::{open_main_repo, repo_workdir_or};
 use crate::utils::interactive;
 use crate::utils::session::{build_session_plan, start_session_for_task};
@@ -48,19 +48,9 @@ pub fn run_with_task(ctx: &AppContext, ident: &str) -> Result<()> {
   }
   // Auto-start when missing using shared session helpers, then attach
   let plan = build_session_plan(ctx, &task)?;
-  let bootstrap_request = plan.bootstrap_request.clone();
 
   crate::utils::daemon::notify_after_task_change(ctx, || {
-    // Send bootstrap request to daemon BEFORE starting session
-    // This ensures fast bootstrap commands complete before the agent starts
-    if let Some(request) = bootstrap_request {
-      send_start_bootstrap(ctx, request);
-    }
-
-    // Start session (creates tmux session and sends agent command)
     start_session_for_task(ctx, &plan, false)?;
-
-    // Attach (this blocks until user detaches)
     interactive::scope(|| tmux::attach_session(&ctx.config, &plan.task_meta))
   })
 }
@@ -340,11 +330,6 @@ fn handle_overlay(
           .map_or_else(|| format!("task-{task_id}"), |t| t.slug.clone());
         let tref = TaskRef { id: task_id, slug };
         let plan = build_session_plan(ctx, &tref)?;
-        let bootstrap_request = plan.bootstrap_request.clone();
-        // Send bootstrap request BEFORE starting session
-        if let Some(request) = bootstrap_request {
-          send_start_bootstrap(ctx, request);
-        }
         let _ = start_session_for_task(ctx, &plan, false);
       }
     }

--- a/crates/agency/src/commands/bootstrap.rs
+++ b/crates/agency/src/commands/bootstrap.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use anyhow::{Context, Result};
 
 use crate::config::AppContext;
-use crate::utils::bootstrap::{create_worktree_for_task, run_bootstrap_in_worktree};
+use crate::utils::bootstrap::{create_worktree_for_task, run_bootstrap_cmd_with_env};
 use crate::utils::git::{ensure_branch_at, open_main_repo, repo_workdir_or, rev_parse};
 use crate::utils::task::{
   TaskFrontmatterExt, branch_name, parse_task_markdown, resolve_id_or_slug, task_file,
@@ -37,7 +37,7 @@ pub fn run(ctx: &AppContext, ident: &str) -> Result<()> {
   let repo_root = repo_workdir_or(&repo, ctx.paths.root());
   let bcfg = ctx.config.bootstrap_config();
   let env_vars: HashMap<String, String> = std::env::vars().collect();
-  run_bootstrap_in_worktree(&repo_root, &wt_result.worktree_dir, &bcfg, &env_vars)?;
+  run_bootstrap_cmd_with_env(&repo_root, &wt_result.worktree_dir, &bcfg, &env_vars);
 
   Ok(())
 }

--- a/crates/agency/src/commands/init.rs
+++ b/crates/agency/src/commands/init.rs
@@ -10,6 +10,10 @@ use crate::utils::log::t;
 const SETUP_TEMPLATE: &str = r#"#!/usr/bin/env bash
 set -euo pipefail
 
+# This script runs synchronously before the agent starts.
+# To run slow commands without blocking, background them with &:
+#   slow-command &
+
 echo "Setup"
 "#;
 

--- a/crates/agency/src/commands/start.rs
+++ b/crates/agency/src/commands/start.rs
@@ -1,5 +1,5 @@
 use crate::config::AppContext;
-use crate::utils::daemon::{get_project_state, send_start_bootstrap};
+use crate::utils::daemon::get_project_state;
 use crate::utils::session::{build_session_plan, start_session_for_task};
 use crate::utils::task::resolve_id_or_slug;
 use anyhow::Result;
@@ -20,19 +20,10 @@ pub fn run_with_attach(ctx: &AppContext, ident: &str, attach: bool) -> Result<()
     anyhow::bail!("Already started. Use attach");
   }
   let plan = build_session_plan(ctx, &task)?;
-  let bootstrap_request = plan.bootstrap_request.clone();
 
   crate::utils::daemon::notify_after_task_change(ctx, || {
-    // Send bootstrap request to daemon BEFORE starting session
-    // This ensures fast bootstrap commands complete before the agent starts
-    if let Some(request) = bootstrap_request {
-      send_start_bootstrap(ctx, request);
-    }
-
-    // Start session (creates tmux session and sends agent command)
     start_session_for_task(ctx, &plan, false)?;
 
-    // Attach if requested (this blocks until user detaches)
     if attach {
       crate::utils::interactive::scope(|| {
         crate::utils::tmux::attach_session(&ctx.config, &plan.task_meta)

--- a/crates/agency/src/daemon_protocol.rs
+++ b/crates/agency/src/daemon_protocol.rs
@@ -1,7 +1,6 @@
 use anyhow::{Context, Result};
 use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::io::{Read, Write};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Encode, Decode)]
@@ -89,11 +88,6 @@ pub enum C2DControl {
     project: ProjectKey,
     task_id: u32,
     slug: String,
-  },
-  /// Start bootstrap process in the background for a task
-  StartBootstrap {
-    project: ProjectKey,
-    request: BootstrapRequest,
   },
   Shutdown,
   Ping {
@@ -189,19 +183,6 @@ pub struct TuiListItem {
   pub tui_id: u32,
   pub pid: u32,
   pub focused_task_id: Option<u32>,
-}
-
-/// Request for starting bootstrap in the background.
-/// Contains all data needed to run `bootstrap_worktree` and `run_bootstrap_cmd`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Encode, Decode)]
-pub struct BootstrapRequest {
-  pub repo_root: String,
-  pub worktree_dir: String,
-  pub task_meta: TaskMeta,
-  pub bootstrap_include: Vec<String>,
-  pub bootstrap_exclude: Vec<String>,
-  pub bootstrap_cmd: Vec<String>,
-  pub env_vars: HashMap<String, String>,
 }
 
 #[cfg(test)]

--- a/crates/agency/src/lib.rs
+++ b/crates/agency/src/lib.rs
@@ -211,20 +211,6 @@ enum DaemonCmd {
 enum BootstrapCmd {
   /// Run bootstrap for a specific task (default when ident provided)
   Task { ident: String },
-  /// Internal: run bootstrap in worktree (called by daemon)
-  #[command(hide = true)]
-  Run {
-    #[arg(long)]
-    repo_root: String,
-    #[arg(long)]
-    worktree_dir: String,
-    #[arg(long = "include", action = clap::ArgAction::Append)]
-    include: Vec<String>,
-    #[arg(long = "exclude", action = clap::ArgAction::Append)]
-    exclude: Vec<String>,
-    #[arg(long = "cmd", action = clap::ArgAction::Append)]
-    cmd: Vec<String>,
-  },
 }
 
 #[derive(Debug, Subcommand)]
@@ -464,16 +450,6 @@ fn run_command(ctx: &AppContext, cli: Cli) -> Result<()> {
       (Some(BootstrapCmd::Task { ident }), _) | (None, Some(ident)) => {
         commands::bootstrap::run(ctx, &ident)
       }
-      (
-        Some(BootstrapCmd::Run {
-          repo_root,
-          worktree_dir,
-          include,
-          exclude,
-          cmd,
-        }),
-        _,
-      ) => commands::bootstrap::run_internal(&repo_root, &worktree_dir, &include, &exclude, &cmd),
       (None, None) => anyhow::bail!("Bootstrap requires a task ID or slug"),
     },
     Some(Commands::Config {}) => commands::config::run(ctx),

--- a/crates/agency/src/utils/bootstrap.rs
+++ b/crates/agency/src/utils/bootstrap.rs
@@ -17,33 +17,13 @@ use gix as git;
 /// Maximum file size for any bootstrap file copying (10MB)
 const MAX_BOOTSTRAP_FILE_BYTES: u64 = 10 * 1024 * 1024;
 
-/// Maximum file size for synchronous copying during worktree creation (100KB)
-/// Files under this threshold are copied immediately; larger files are handled in background.
-const SYNC_BOOTSTRAP_FILE_BYTES: u64 = 100 * 1024;
-
-/// Copy small gitignored root files synchronously during worktree creation.
-///
-/// This ensures commonly-needed files like .env are available immediately
-/// when the user attaches to the session, without waiting for background bootstrap.
-pub fn sync_copy_small_gitignored_files(
-  root_workdir: &Path,
-  dst_worktree: &Path,
-  cfg: &BootstrapConfig,
-) -> Result<()> {
-  copy_gitignored_root_files(root_workdir, dst_worktree, cfg, Some(SYNC_BOOTSTRAP_FILE_BYTES))
-}
-
-/// Bootstrap a worktree by copying larger gitignored files and included directories.
-///
-/// This runs in the background and handles files larger than the sync threshold,
-/// as well as directories explicitly included in the bootstrap config.
+/// Bootstrap a worktree by copying gitignored root files and included directories.
 pub fn bootstrap_worktree(
   root_workdir: &Path,
   dst_worktree: &Path,
   cfg: &BootstrapConfig,
 ) -> Result<()> {
-  // Copy remaining large files (small ones were already copied synchronously)
-  copy_gitignored_root_files(root_workdir, dst_worktree, cfg, None)?;
+  copy_gitignored_root_files(root_workdir, dst_worktree, cfg)?;
 
   // Copy explicitly included files and directories using glob patterns
   for pattern in &cfg.include {
@@ -92,13 +72,11 @@ pub fn bootstrap_worktree(
 
 /// Copy gitignored root files to the worktree.
 ///
-/// If `max_size` is Some, only files under that size are copied.
 /// Files that already exist in the destination are skipped.
 fn copy_gitignored_root_files(
   root_workdir: &Path,
   dst_worktree: &Path,
   cfg: &BootstrapConfig,
-  max_size: Option<u64>,
 ) -> Result<()> {
   let entries = discover_root_entries(root_workdir)?;
 
@@ -147,13 +125,6 @@ fn copy_gitignored_root_files(
       continue;
     }
 
-    // If max_size is specified, only copy files within that size
-    if let Some(max) = max_size
-      && size > max
-    {
-      continue;
-    }
-
     let dst_path = dst_worktree.join(name);
     if dst_path.exists() {
       continue;
@@ -193,17 +164,17 @@ fn copy_included_file(src: &Path, dst: &Path) -> Result<()> {
 /// Result from creating a worktree.
 pub struct CreateWorktreeResult {
   pub worktree_dir: PathBuf,
-  /// True if the worktree was newly created (bootstrap will run in background)
+  /// True if the worktree was newly created (bootstrap cmd still needs to run)
   pub is_new: bool,
 }
 
-/// Create a worktree for a task (fast, synchronous).
+/// Create a worktree for a task and copy bootstrap files synchronously.
 ///
-/// This creates the git worktree, files symlink, and copies small gitignored files
-/// (like .env) synchronously. Larger files and directories are handled by
-/// `run_bootstrap_in_worktree` in the background.
+/// This creates the git worktree, files symlink, and copies all gitignored files
+/// and included directories. The bootstrap command is NOT run here (it needs
+/// environment variables built later); callers should run it separately.
 ///
-/// Returns the worktree path and whether background bootstrap is needed.
+/// Returns the worktree path and whether the bootstrap command needs to run.
 pub fn create_worktree_for_task(
   ctx: &AppContext,
   repo: &git::Repository,
@@ -227,12 +198,12 @@ pub fn create_worktree_for_task(
 
   create_files_symlink(&ctx.paths, task, &worktree_dir_path);
 
-  // Copy small gitignored files synchronously (like .env) so they're available immediately
+  // Copy all bootstrap files synchronously so they're available before the agent starts
   if is_new {
     let repo_root = repo_workdir_or(repo, ctx.paths.root());
     let bcfg = ctx.config.bootstrap_config();
-    if let Err(err) = sync_copy_small_gitignored_files(&repo_root, &worktree_dir_path, &bcfg) {
-      log_warn!("Failed to copy small gitignored files: {err}");
+    if let Err(err) = bootstrap_worktree(&repo_root, &worktree_dir_path, &bcfg) {
+      log_warn!("Failed to copy bootstrap files: {err}");
     }
   }
 
@@ -246,7 +217,7 @@ pub fn create_worktree_for_task(
   })
 }
 
-/// Run bootstrap operations in a worktree (slow, meant for background execution).
+/// Run full bootstrap in a worktree: copy files and run the bootstrap command.
 ///
 /// This copies gitignored files and runs the bootstrap command.
 /// Receives pre-built environment variables from the caller.
@@ -262,7 +233,7 @@ pub fn run_bootstrap_in_worktree(
 }
 
 /// Run the configured bootstrap command with custom environment variables.
-fn run_bootstrap_cmd_with_env(
+pub fn run_bootstrap_cmd_with_env(
   repo_root: &Path,
   worktree_dir: &Path,
   cfg: &BootstrapConfig,

--- a/crates/agency/src/utils/bootstrap.rs
+++ b/crates/agency/src/utils/bootstrap.rs
@@ -217,21 +217,6 @@ pub fn create_worktree_for_task(
   })
 }
 
-/// Run full bootstrap in a worktree: copy files and run the bootstrap command.
-///
-/// This copies gitignored files and runs the bootstrap command.
-/// Receives pre-built environment variables from the caller.
-pub fn run_bootstrap_in_worktree(
-  repo_root: &Path,
-  worktree_dir: &Path,
-  cfg: &BootstrapConfig,
-  env_vars: &std::collections::HashMap<String, String>,
-) -> anyhow::Result<()> {
-  bootstrap_worktree(repo_root, worktree_dir, cfg)?;
-  run_bootstrap_cmd_with_env(repo_root, worktree_dir, cfg, env_vars);
-  Ok(())
-}
-
 /// Run the configured bootstrap command with custom environment variables.
 pub fn run_bootstrap_cmd_with_env(
   repo_root: &Path,

--- a/crates/agency/src/utils/daemon.rs
+++ b/crates/agency/src/utils/daemon.rs
@@ -1,7 +1,7 @@
 use crate::config::{AppContext, compute_socket_path};
 use crate::daemon_protocol::{
-  BootstrapRequest, C2D, C2DControl, D2C, D2CControl, ProjectKey, SessionInfo, TaskInfo,
-  TaskMetrics, TuiListItem, read_frame, write_frame,
+  C2D, C2DControl, D2C, D2CControl, ProjectKey, SessionInfo, TaskInfo, TaskMetrics, TuiListItem,
+  read_frame, write_frame,
 };
 use crate::log_warn;
 use crate::utils::git::{open_main_repo, repo_workdir_or};
@@ -202,29 +202,6 @@ pub fn tui_list(ctx: &AppContext) -> anyhow::Result<Vec<TuiListItem>> {
     D2C::Control(D2CControl::TuiList { items }) => Ok(items),
     D2C::Control(D2CControl::Error { message }) => anyhow::bail!(message),
     D2C::Control(_) => anyhow::bail!("Protocol error: expected TuiList reply"),
-  }
-}
-
-/// Send a bootstrap request to the daemon for background execution.
-///
-/// This is best-effort: if the daemon is unavailable, it logs a warning and continues.
-pub fn send_start_bootstrap(ctx: &AppContext, request: BootstrapRequest) {
-  let socket = compute_socket_path(&ctx.config);
-  let repo = match open_main_repo(ctx.paths.root()) {
-    Ok(r) => r,
-    Err(err) => {
-      log_warn!("Failed to open repo for bootstrap request: {}", err);
-      return;
-    }
-  };
-  let repo_root = repo_workdir_or(&repo, ctx.paths.root());
-  let project = ProjectKey {
-    repo_root: repo_root.display().to_string(),
-  };
-
-  if let Err(err) = send_message_to_daemon(&socket, C2DControl::StartBootstrap { project, request })
-  {
-    log_warn!("Failed to send bootstrap request to daemon: {}", err);
   }
 }
 


### PR DESCRIPTION
This PR fixes setup script execution to be synchronous again and removes redundant file-copying in the bootstrap CLI path.

## Changes

- **Restore synchronous bootstrap execution** – setup scripts were running asynchronously, which could cause race conditions. This restores the previous synchronous behavior.
- **Remove redundant file-copying in bootstrap CLI path** – cleans up unnecessary file copy logic that was no longer needed.